### PR TITLE
f#162444714 Fix: Token not returned during signup

### DIFF
--- a/authors/apps/authentication/tests/test_token_generation.py
+++ b/authors/apps/authentication/tests/test_token_generation.py
@@ -1,0 +1,44 @@
+import json
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+
+
+class TestTokenGeneration(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user1 = dict(user=dict(
+            username="silaskenn",
+            email='silaskenn@gmail.com',
+            password="SilasK@2019"
+        ))
+        self.user2 = dict(user=dict(
+            email='silaskenn@gmail.com',
+            password="SilasK@2019"
+        ))
+        self.REGISTER_URL = reverse("authentication:user-signup")
+        self.LOGIN_URL = reverse("authentication:user-login")
+
+    def test_can_get_signup_token(self):
+        content = self.client.post(self.REGISTER_URL,
+                                   data=json.dumps(self.user1),
+                                   content_type="application/json")
+        # decoded = json.loads(content.data)
+        token_from_signup = content.data.get("token", "")
+        self.assertEqual(content.status_code, status.HTTP_201_CREATED)
+        self.assertNotEqual(token_from_signup, "")
+
+    def test_can_get_login_token(self):
+        posted = self.client.post(self.REGISTER_URL,
+                                  data=json.dumps(self.user1),
+                                  content_type="application/json")
+        content = self.client.post(self.LOGIN_URL,
+                                   data=json.dumps(self.user2),
+                                   content_type="application/json")
+        self.assertEqual(posted.status_code, status.HTTP_201_CREATED)
+        print(content.data)
+        self.assertEqual(content.status_code, status.HTTP_200_OK)
+
+        token_from_login = content.data.get('token', '')
+        self.assertNotEqual(token_from_login, '')


### PR DESCRIPTION
#### What does this PR do?
As in the PR #11 the application is supposed to return token during login and signup. But due to some bugs with the signup, the token was never returned to the user on signup. 
#### Description of Task to be completed?
Users once registered via the registration endpoint, should receive a JWT to be required on all subsequent calls to all other endpoints that require authentication.
#### How should this be manually tested?
To test the application follow the steps below.
 - Clone the repo using `git clone https://github.com/andela/ah-technocrats.git`
 - `cd ah-technocrats`
 - `git checkout fix-no-token-signup-162444714` to switch to current branch
 - run `virtualenv env -p python3` to create a virtual environment for the application
 - Activate the environment `source env/bin/activate`
 - Install required modules  using `pip install -r requirements.txt`
 - run `python manage.py test` to test
#### Any background context you want to provide?
- The project requires that you have python version 3 installed. For the Django version the project has just been tested with Django 2.1 which is the latest version as of this PR.
#### What are the relevant pivotal tracker stories?
[#161966604](https://www.pivotaltracker.com/n/projects/2225606/stories/162444714)

# Checklist:
- [x] My code follows the style guidelines of this project
- [ ] At least 2 people have reviewed my PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My PR has one commit.

# Screenshots
<img width="1440" alt="screenshot 2018-12-06 12 09 18" src="https://user-images.githubusercontent.com/11555354/49573747-cf45f080-f94f-11e8-9b36-41a47b3a00ba.png">
